### PR TITLE
Small fixes

### DIFF
--- a/pykdl_ros/CMakeLists.txt
+++ b/pykdl_ros/CMakeLists.txt
@@ -10,7 +10,7 @@ catkin_python_setup()
 catkin_package(
   INCLUDE_DIRS
   LIBRARIES
-  CATKIN_DEPENDS std_msgs rospy
+  CATKIN_DEPENDS genpy std_msgs
   DEPENDS
 )
 

--- a/pykdl_ros/package.xml
+++ b/pykdl_ros/package.xml
@@ -18,8 +18,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>genpy</exec_depend>
   <exec_depend>python_orocos_kdl</exec_depend>
-  <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <doc_depend>python3-sphinx</doc_depend>

--- a/pykdl_ros/src/pykdl_ros/pykdl_ros.py
+++ b/pykdl_ros/src/pykdl_ros/pykdl_ros.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from rospy import Time
+from genpy import Time
 import PyKDL as kdl
 from std_msgs.msg import Header
 

--- a/pykdl_ros/src/pykdl_ros/pykdl_ros.py
+++ b/pykdl_ros/src/pykdl_ros/pykdl_ros.py
@@ -59,7 +59,7 @@ class FrameStamped:
         :return: Filled object
         """
         vector = kdl.Vector(x, y, z)
-        rotation = kdl.Rotation(roll, pitch, yaw)
+        rotation = kdl.Rotation.RPY(roll, pitch, yaw)
         frame = kdl.Frame(rotation, vector)
         return cls(frame, stamp, frame_id)
 

--- a/tf2_pykdl_ros/src/tf2_pykdl_ros/tf2_pykdl_ros.py
+++ b/tf2_pykdl_ros/src/tf2_pykdl_ros/tf2_pykdl_ros.py
@@ -104,10 +104,10 @@ def to_msg_frame(frame: FrameStamped) -> PoseStamped:
     msg.pose.position.y = v[1]
     msg.pose.position.z = v[2]
     q = frame.frame.M.GetQuaternion()
-    msg.pose.orientation.x = q.x
-    msg.pose.orientation.y = q.y
-    msg.pose.orientation.z = q.z
-    msg.pose.orientation.w = q.w
+    msg.pose.orientation.x = q[0]
+    msg.pose.orientation.y = q[1]
+    msg.pose.orientation.z = q[2]
+    msg.pose.orientation.w = q[3]
     return msg
 
 


### PR DESCRIPTION
This allows writing message stamps directly without wrapping to `rospy.Time`

Might be a good idea to extend the tests